### PR TITLE
#4 исправление is_based_on_ostream

### DIFF
--- a/include/sayan/cursor/ostream.hpp
+++ b/include/sayan/cursor/ostream.hpp
@@ -104,7 +104,7 @@ inline namespace v1
             template <class Char, class Traits>
             static std::true_type test(std::basic_ostream<Char, Traits> &);
 
-            static std::false_type test(void *);
+            static std::false_type test(...);
 
         public:
             using type = decltype(test(std::declval<T&>()));

--- a/sayan_test/tests/ostream.cpp
+++ b/sayan_test/tests/ostream.cpp
@@ -52,3 +52,21 @@ TEST_CASE("ostream_cursor from rvalue range-for copy")
     CHECK(src == os.str());
 }
 
+TEST_CASE("is_based_ostream_test")
+{
+    static_assert(::sayan::is_based_on_ostream<std::ostream>::value, "");
+    static_assert(::sayan::is_based_on_ostream<std::ostream&>::value, "");
+    static_assert(::sayan::is_based_on_ostream<std::ostringstream>::value, "");
+
+    static_assert(!::sayan::is_based_on_ostream<std::ostream const>::value, "");
+    static_assert(!::sayan::is_based_on_ostream<int>::value, "");
+    static_assert(!::sayan::is_based_on_ostream<std::vector<int>>::value, "");
+
+    CHECK(::sayan::is_based_on_ostream<std::ostream>::value);
+    CHECK(::sayan::is_based_on_ostream<std::ostream&>::value);
+    CHECK(::sayan::is_based_on_ostream<std::ostringstream>::value);
+
+    CHECK_FALSE(::sayan::is_based_on_ostream<std::ostream const>::value);
+    CHECK_FALSE(::sayan::is_based_on_ostream<int>::value);
+    CHECK_FALSE(::sayan::is_based_on_ostream<std::vector<int>>::value);
+}


### PR DESCRIPTION
Ошибка возникала, когда шаблонный параметр не был производным от basic_ostream
Заменили в функции, возвращающей false_type void * на ...